### PR TITLE
Add biocViews keyword to DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,6 +10,7 @@ LazyData: true
 LinkingTo: Rcpp
 Depends: Rcpp, signal, pheatmap, RColorBrewer, IRanges, grid, ggplot2, reshape, mclust,  ggpubr, scales, gridExtra, igraph, intergraph, ggnetwork, ape, biomaRt, limma, GO.db, org.Hs.eg.db, GOstats, GenomicRanges
 RoxygenNote: 6.1.1
+biocViews:
 Suggests: knitr,
     rmarkdown
 VignetteBuilder: knitr


### PR DESCRIPTION
Trivial addition, but this makes `install_github` to automatically resolve Bioconductor packages - no need to install them manually beforehand. 